### PR TITLE
refact: bugfix e desativando percona temporariamente

### DIFF
--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/acompanhamento/AcompanhamentoRepository.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/acompanhamento/AcompanhamentoRepository.java
@@ -13,7 +13,12 @@ public interface AcompanhamentoRepository extends JpaRepository<Acompanhamento, 
   // data de envio em ordem crescente
   List<Acompanhamento> findByDenunciaIdOrderByDataEnvioAsc(Long denunciaId);
 
+  /**
+   * 
+   * O método abaixo não foi construído corretamente e está causando erro
+   * 
+   */
   // retorna todos os acompanhamentos de uma denúncia específica via token,
   // ordenados pela data de envio em ordem decrescente
-  List<Acompanhamento> findByDenunciaTokenOrderByDataEnvioDesc(UUID token);
+  // List<Acompanhamento> findByDenunciaTokenOrderByDataEnvioDesc(UUID token);
 }

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/security/recaptcha/RecaptchaService.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/security/recaptcha/RecaptchaService.java
@@ -9,9 +9,8 @@ import br.edu.ifpi.ifala.security.recaptcha.recaptchaDTO.RecaptchaResponseDto;
 import reactor.core.publisher.Mono;
 
 /**
- * Serviço para validação do reCAPTCHA do Google.
- * Esta classe utiliza o WebClient para enviar requisições ao serviço reCAPTCHA
- * e validar tokens.
+ * Serviço para validação do reCAPTCHA do Google. Esta classe utiliza o WebClient para enviar
+ * requisições ao serviço reCAPTCHA e validar tokens.
  *
  * @author Jhonatas G Ribeiro
  */
@@ -21,8 +20,14 @@ public class RecaptchaService {
   private final WebClient webClient;
   private final RecaptchaConfig recaptchaConfig;
 
-  public RecaptchaService(WebClient.Builder webClientBuilder, RecaptchaConfig recaptchaConfig) {
-    this.webClient = webClientBuilder.baseUrl(recaptchaConfig.getUrl()).build();
+  /**
+   * É preciso criar um Bean para o WebClient se for usá-lo desta forma (no construtor), através de
+   * uma classe @Component ou @Configuration. Irei desabilitar, pois está causando erro. Recomendo
+   * utilizar RestClient.
+   */
+  public RecaptchaService(
+      /* WebClient.Builder webClientBuilder, */RecaptchaConfig recaptchaConfig) {
+    this.webClient = WebClient.builder().baseUrl(recaptchaConfig.getUrl()).build();
     this.recaptchaConfig = recaptchaConfig;
   }
 
@@ -31,11 +36,8 @@ public class RecaptchaService {
     formData.add("secret", recaptchaConfig.getSecret());
     formData.add("response", token);
 
-    return this.webClient.post()
-        .bodyValue(formData)
-        .retrieve()
-        .bodyToMono(RecaptchaResponseDto.class)
-        .map(RecaptchaResponseDto::isSuccess)
+    return this.webClient.post().bodyValue(formData).retrieve()
+        .bodyToMono(RecaptchaResponseDto.class).map(RecaptchaResponseDto::isSuccess)
         .onErrorReturn(false); // Erro de comunicação retorna falso
   }
 }

--- a/apps/ifala-backend/src/test/java/br/edu/ifpi/ifala/IfalaApplicationTests.java
+++ b/apps/ifala-backend/src/test/java/br/edu/ifpi/ifala/IfalaApplicationTests.java
@@ -6,8 +6,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class IfalaApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+  @Test
+  void contextLoads() {}
 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,50 +77,50 @@ services:
     ports:
       - '9090:8080'
 
-  pmm-server:
-    image: percona/pmm-server:2
-    container_name: pmm-server
-    restart: unless-stopped
-    ports:
-      - '8081:80'
-      - '8444:443'
-    volumes:
-      - pmm-data:/srv
+  # pmm-server:
+  #   image: percona/pmm-server:2
+  #   container_name: pmm-server
+  #   restart: unless-stopped
+  #   ports:
+  #     - '8081:80'
+  #     - '8444:443'
+  #   volumes:
+  #     - pmm-data:/srv
 
-  pmm-client:
-    image: percona/pmm-client:2
-    container_name: pmm-client
-    restart: unless-stopped
-    depends_on:
-      pmm-server:
-        condition: service_started
-      postgres:
-        condition: service_healthy
-    environment:
-      PMM_AGENT_SERVER_ADDRESS: pmm-server
-      PMM_AGENT_SERVER_USERNAME: admin
-      PMM_AGENT_SERVER_PASSWORD: admin
-      DB_HOST: postgres
-      DB_PORT: 5432
-      DB_USER: postgres
-      DB_PASSWORD: postgres
-    command: >-
-      /bin/bash -c " pmm-agent setup \
-        --config-file=/usr/local/percona/pmm-agent.yaml \
-        --server-address=${PMM_AGENT_SERVER_ADDRESS}:443 \
-        --server-username=${PMM_AGENT_SERVER_USERNAME} \
-        --server-password=${PMM_AGENT_SERVER_PASSWORD} \
-        --server-insecure-tls \
-        --force &&
-      pmm-admin add postgresql \
-        --username=${DB_USER} \
-        --password=${DB_PASSWORD} \
-        --host=${DB_HOST} \
-        --port=${DB_PORT} \
-        ifala-db &&
-      tail -f /dev/null "
+  # pmm-client:
+  #   image: percona/pmm-client:2
+  #   container_name: pmm-client
+  #   restart: unless-stopped
+  #   depends_on:
+  #     pmm-server:
+  #       condition: service_started
+  #     postgres:
+  #       condition: service_healthy
+  #   environment:
+  #     PMM_AGENT_SERVER_ADDRESS: pmm-server
+  #     PMM_AGENT_SERVER_USERNAME: admin
+  #     PMM_AGENT_SERVER_PASSWORD: admin
+  #     DB_HOST: postgres
+  #     DB_PORT: 5432
+  #     DB_USER: postgres
+  #     DB_PASSWORD: postgres
+  #   command: >-
+  #     /bin/bash -c " pmm-agent setup \
+  #       --config-file=/usr/local/percona/pmm-agent.yaml \
+  #       --server-address=${PMM_AGENT_SERVER_ADDRESS}:443 \
+  #       --server-username=${PMM_AGENT_SERVER_USERNAME} \
+  #       --server-password=${PMM_AGENT_SERVER_PASSWORD} \
+  #       --server-insecure-tls \
+  #       --force &&
+  #     pmm-admin add postgresql \
+  #       --username=${DB_USER} \
+  #       --password=${DB_PASSWORD} \
+  #       --host=${DB_HOST} \
+  #       --port=${DB_PORT} \
+  #       ifala-db &&
+  #     tail -f /dev/null "
 
 volumes:
   pgdata:
   keycloak_data:
-  pmm-data:
+  #pmm-data:


### PR DESCRIPTION
### Ajustes aplicados

- fix checkstyle em `IfalaApplicationTests`
- fix chamada `WebClient.Builder` no construtor do `RecaptchaService`. Para utilizar o WebClient no construtor é preciso configurar um `@Bean` em uma classe anotada com `@Component` ou `@Configuration`. De qualquer forma, recomendo a utilização do RestClient para realizar uma chamada síncrona.
- Desativei o Percona PMM temporariamente, devido ao alto consumo de memória e considerável espaço em disco necessário. Como este projeto é muito simples, talvez não seja realmente necessário utilizá-lo, mas apenas comentei os serviços do Percona PMM caso precisemos dele futuramente.