### PR TITLE
fix(jpa): Implementa equals, hashCode, Serializable e toString 

### DIFF
--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/acompanhamento/Acompanhamento.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/acompanhamento/Acompanhamento.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 /**
@@ -15,7 +16,9 @@ import java.time.LocalDateTime;
  * @author Renê Morais
  */
 @Entity
-public class Acompanhamento {
+public class Acompanhamento implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -76,4 +79,34 @@ public class Acompanhamento {
     this.dataEnvio = dataEnvio;
   }
 
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Acompanhamento)) {
+      return false;
+    }
+    Acompanhamento other = (Acompanhamento) o;
+
+    return id != null && id.equals(other.getId());
+  }
+
+
+  @Override
+  public int hashCode() {
+    return getClass().hashCode();
+  }
+
+  @Override
+  public String toString() {
+    // O campo 'denuncia' foi trocado por 'denunciaId' para evitar
+    // um loop infinito de logs (StackOverflowError).
+    Long denunciaId = (denuncia != null) ? denuncia.getId() : null;
+
+    return "Acompanhamento{" + "id=[" + id + "]" + ", autor=[" + autor + "]" + ", mensagem=["
+        + mensagem + "]" + ", denunciaId=[" + denunciaId + "]" + ", dataEnvio=[" + dataEnvio + "]"
+        + "}";
+  }
 }

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/Denuncia.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/Denuncia.java
@@ -16,24 +16,24 @@ import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
 /**
- * Classe que representa uma denúncia no sistema. Esta entidade armazena
- * informações sobre
- * denúncias, incluindo sua descrição, categoria, status e histórico de
- * acompanhamentos.
+ * Classe que representa uma denúncia no sistema. Esta entidade armazena informações sobre
+ * denúncias, incluindo sua descrição, categoria, status e histórico de acompanhamentos.
  *
  * @author Renê Morais
  * @author Jhonatas G Ribeiro
  */
 @Entity
 @Table(name = "denuncias")
-public class Denuncia {
+public class Denuncia implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -74,8 +74,7 @@ public class Denuncia {
   private String recaptchaToken;
 
   /**
-   * Construtor padrão que inicializa uma nova denúncia. Define um token de
-   * acompanhamento único,
+   * Construtor padrão que inicializa uma nova denúncia. Define um token de acompanhamento único,
    * status inicial como RECEBIDO e a data/hora de criação.
    */
 
@@ -172,5 +171,32 @@ public class Denuncia {
   public void setAlteradoEm(LocalDateTime alteradoEm) {
     this.alteradoEm = alteradoEm;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Denuncia)) {
+      return false;
+    }
+    Denuncia other = (Denuncia) o;
+    return id != null && id.equals(other.getId());
+  }
+
+  @Override
+  public int hashCode() {
+    return getClass().hashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "Denuncia{" + "id=[" + id + "]" + ", descricao=[" + descricao + "]" + ", categoria=["
+        + categoria + "]" + ", status=[" + status + "]" + ", motivoRejeicao=[" + motivoRejeicao
+        + "]" + ", tokenAcompanhamento=[" + tokenAcompanhamento + "]" + ", criadoEm=[" + criadoEm
+        + "]" + ", alteradoPor=[" + alteradoPor + "]" + ", alteradoEm=[" + alteradoEm + "]" + "}";
+  }
+
+
 
 }

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/notificacao/Notificacao.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/notificacao/Notificacao.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import java.io.Serializable;
 import java.time.LocalDateTime;
 
 /**
@@ -17,7 +18,9 @@ import java.time.LocalDateTime;
  * @author Renê Morais
  */
 @Entity
-public class Notificacao {
+public class Notificacao implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -92,6 +95,34 @@ public class Notificacao {
 
   public void setDataEnvio(LocalDateTime dataEnvio) {
     this.dataEnvio = dataEnvio;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof Notificacao)) {
+      return false;
+    }
+    Notificacao other = (Notificacao) o;
+    return id != null && id.equals(other.getId());
+  }
+
+  @Override
+  public int hashCode() {
+    return getClass().hashCode();
+  }
+
+  @Override
+  public String toString() {
+    // O campo 'denuncia' foi trocado por 'denunciaId' para evitar
+    // um loop infinito de logs (StackOverflowError).
+    Long denunciaId = (denuncia != null) ? denuncia.getId() : null;
+
+    return "Notificacao{" + "id=[" + id + "]" + ", conteudo=[" + conteudo + "]" + ", tipo=[" + tipo
+        + "]" + ", denunciaId=[" + denunciaId + "]" + ", lida=[" + lida + "]" + ", lidaPor=["
+        + lidaPor + "]" + ", dataEnvio=[" + dataEnvio + "]" + "}";
   }
 
 }

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/CategoriaEntity.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/CategoriaEntity.java
@@ -2,6 +2,7 @@ package br.edu.ifpi.ifala.utils.entities;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.io.Serializable;
 
 /**
  * Entidade JPA que representa a tabela enum_categorias no banco de dados.
@@ -11,7 +12,9 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "enum_categorias")
-public class CategoriaEntity extends EnumEntity {
+public class CategoriaEntity extends EnumEntity implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   public CategoriaEntity() {
     super();
@@ -20,4 +23,27 @@ public class CategoriaEntity extends EnumEntity {
   public CategoriaEntity(String value, String label) {
     super(value, label);
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CategoriaEntity)) {
+      return false;
+    }
+    CategoriaEntity other = (CategoriaEntity) o;
+
+    // getter 'getId()' pois o campo 'id' está na superclasse EnumEntity
+    return getId() != null && getId().equals(other.getId());
+  }
+
+  // Adaptado para herança, usando getters
+  @Override
+  public String toString() {
+
+    return "CategoriaEntity{" + "id=[" + getId() + "]" + ", value=[" + getValue() + "]"
+        + ", label=[" + getLabel() + "]" + "}";
+  }
+
 }

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/CursoEntity.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/CursoEntity.java
@@ -2,6 +2,7 @@ package br.edu.ifpi.ifala.utils.entities;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.io.Serializable;
 
 /**
  * Entidade JPA que representa a tabela enum_cursos no banco de dados.
@@ -11,7 +12,9 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "enum_cursos")
-public class CursoEntity extends EnumEntity {
+public class CursoEntity extends EnumEntity implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   public CursoEntity() {
     super();
@@ -19,5 +22,25 @@ public class CursoEntity extends EnumEntity {
 
   public CursoEntity(String value, String label) {
     super(value, label);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof CursoEntity)) {
+      return false;
+    }
+    CursoEntity other = (CursoEntity) o;
+
+    return getId() != null && getId().equals(other.getId());
+  }
+
+  @Override
+  public String toString() {
+
+    return "CursoEntity{" + "id=[" + getId() + "]" + ", value=[" + getValue() + "]" + ", label=["
+        + getLabel() + "]" + "}";
   }
 }

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/EnumEntity.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/EnumEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import java.io.Serializable;
 
 /**
  * Classe base para entidades de enumerações. Contém os campos comuns id, value e label.
@@ -13,7 +14,9 @@ import jakarta.persistence.MappedSuperclass;
  */
 
 @MappedSuperclass
-public abstract class EnumEntity {
+public abstract class EnumEntity implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,8 +28,7 @@ public abstract class EnumEntity {
   @Column(nullable = false, length = 255)
   private String label;
 
-  public EnumEntity() {
-  }
+  public EnumEntity() {}
 
   public EnumEntity(String value, String label) {
     this.value = value;
@@ -56,4 +58,32 @@ public abstract class EnumEntity {
   public void setLabel(String label) {
     this.label = label;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    EnumEntity other = (EnumEntity) o;
+
+    return id != null && id.equals(other.getId());
+  }
+
+  @Override
+  public int hashCode() {
+    return getClass().hashCode();
+  }
+
+
+  @Override
+  public String toString() {
+    return "EnumEntity{" + "id=" + id + ", value='" + value + '\'' + ", label='" + label + '\''
+        + '}';
+  }
+
 }

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/GrauEntity.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/GrauEntity.java
@@ -2,6 +2,7 @@ package br.edu.ifpi.ifala.utils.entities;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.io.Serializable;
 
 /**
  * Entidade JPA que representa a tabela enum_graus no banco de dados.
@@ -12,7 +13,9 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "enum_graus")
-public class GrauEntity extends EnumEntity {
+public class GrauEntity extends EnumEntity implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   public GrauEntity() {
     super();
@@ -20,5 +23,11 @@ public class GrauEntity extends EnumEntity {
 
   public GrauEntity(String value, String label) {
     super(value, label);
+  }
+
+  @Override
+  public String toString() {
+    return "GrauEntity{" + "id=[" + getId() + "]" + ", value=[" + getValue() + "]" + ", label=["
+        + getLabel() + "]" + "}";
   }
 }

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/StatusEntity.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/StatusEntity.java
@@ -2,6 +2,7 @@ package br.edu.ifpi.ifala.utils.entities;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.io.Serializable;
 
 /**
  * Entidade JPA que representa a tabela enum_status no banco de dados.
@@ -12,7 +13,9 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "enum_status")
-public class StatusEntity extends EnumEntity {
+public class StatusEntity extends EnumEntity implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   public StatusEntity() {
     super();
@@ -20,5 +23,11 @@ public class StatusEntity extends EnumEntity {
 
   public StatusEntity(String value, String label) {
     super(value, label);
+  }
+
+  @Override
+  public String toString() {
+    return "StatusEntity{" + "id=[" + getId() + "]" + ", value=[" + getValue() + "]" + ", label=["
+        + getLabel() + "]" + "}";
   }
 }

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/TurmaEntity.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/utils/entities/TurmaEntity.java
@@ -2,6 +2,8 @@ package br.edu.ifpi.ifala.utils.entities;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import java.io.Serializable;
+
 
 /**
  * Entidade JPA que representa a tabela enum_turmas no banco de dados.
@@ -11,7 +13,9 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "enum_turmas")
-public class TurmaEntity extends EnumEntity {
+public class TurmaEntity extends EnumEntity implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   public TurmaEntity() {
     super();
@@ -19,5 +23,11 @@ public class TurmaEntity extends EnumEntity {
 
   public TurmaEntity(String value, String label) {
     super(value, label);
+  }
+
+  @Override
+  public String toString() {
+    return "TurmaEntity{" + "id=[" + getId() + "]" + ", value=[" + getValue() + "]" + ", label=["
+        + getLabel() + "]}";
   }
 }


### PR DESCRIPTION
Este pull request implementa os requisitos da tarefa de refatoração das entidades JPA, garantindo a correta implementação de equals, hashCode, Serializable e toString.

O objetivo é padronizar as entidades, evitar problemas de persistência no Hibernate e).

O que este PR faz:

Implementa Serializable: Todas as entidades @Entity e a superclasse @MappedSuperclass agora implementam Serializable e possuem o atributo serialVersionUID = 1L, conforme especificado.

Implementa equals() e hashCode(): Os métodos foram implementados seguindo a recomendação do artigo (baseado no ID da entidade e getClass()). A lógica principal foi centralizada na superclasse EnumEntity para evitar duplicação de código nas entidades filhas.

Implementa toString(): Um método toString() padronizado foi adicionado a todas as entidades, seguindo o formato solicitado (Classe{campo=[valor]}) para facilitar a depuração e os logs do sistema.
