### PR TITLE
Fix: placeholder acompanhar denuncia staging

### DIFF
--- a/apps/ifala-frontend/src/App.css
+++ b/apps/ifala-frontend/src/App.css
@@ -377,11 +377,37 @@
 
 .token-input input {
   width: 100%;
-  padding: 12px;
+  padding: 16px 20px;
   border: 2px solid var(--azul-confianca);
   border-radius: 8px;
-  font-size: 16px;
+  font-size: 14px;
   margin-bottom: 1rem;
+  min-height: 52px;
+  box-sizing: border-box;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.token-input input::placeholder {
+  color: #999;
+  font-size: 13px;
+  opacity: 1;
+  white-space: normal;
+  word-wrap: break-word;
+}
+
+/* Ajuste para mobile */
+@media (max-width: 768px) {
+  .token-input input {
+    font-size: 14px;
+    padding: 14px 16px;
+    min-height: 48px;
+  }
+
+  .token-input input::placeholder {
+    font-size: 12px;
+  }
 }
 
 /* Security Section */

--- a/apps/ifala-frontend/src/pages/Home/Home.tsx
+++ b/apps/ifala-frontend/src/pages/Home/Home.tsx
@@ -93,7 +93,7 @@ export function Home() {
                 <div className={`token-input ${showTokenInput ? 'show' : ''}`}>
                   <input
                     type='text'
-                    placeholder='Digite seu token de acompanhamento'
+                    placeholder='Digite o token de acompanhamento'
                     value={token}
                     onChange={(e) => setToken(e.target.value)}
                   />


### PR DESCRIPTION
Agora o Placeholder está okay e por precaução verifiquei no mobile e também estava quebrado, estão modifiquei o código para ser responsivo para Mobile.

O que for necessário para mobile é só jogar aqui dentro agora:

```css
/* Ajuste para mobile */
@media (max-width: 768px) {
  .token-input input {
    font-size: 14px;
    padding: 14px 16px;
    min-height: 48px;
  }

  .token-input input::placeholder {
    font-size: 12px;
  }
}
```

DESKTOP:

<img width="548" height="623" alt="Captura de tela 2025-10-21 153925" src="https://github.com/user-attachments/assets/e2a588cb-123c-46ad-b091-f26ddb2fdc70" />


MOBILE:

![mobile](https://github.com/user-attachments/assets/27ae4bb1-0e78-43db-9280-41dc614b1abf)

