### PR TITLE
fix: corrige responsividade dos botões na tela de sucesso

### DIFF
--- a/apps/ifala-frontend/src/pages/DenunciaSucesso/DenunciaSucesso.tsx
+++ b/apps/ifala-frontend/src/pages/DenunciaSucesso/DenunciaSucesso.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Paper,
   Snackbar,
+  Stack,
 } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
@@ -166,12 +167,21 @@ export function DenunciaSucesso() {
         </Alert>
 
         {/* Actions */}
-        <Box sx={{ display: 'flex', gap: 2, justifyContent: 'center', mt: 1 }}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          justifyContent='center'
+          alignItems={{ xs: 'stretch', sm: 'center' }}
+          sx={{ mt: 1 }}
+        >
           <Button
             variant='contained'
             color='success'
             onClick={() => navigate('/acompanhamento', { state: { token } })}
-            sx={{ minWidth: 220 }}
+            sx={{
+              width: { xs: '100%', sm: 'auto' },
+              minWidth: { xs: '100%', sm: 220 },
+            }}
           >
             Acompanhar Agora
           </Button>
@@ -180,7 +190,8 @@ export function DenunciaSucesso() {
             variant='outlined'
             onClick={() => navigate('/')}
             sx={{
-              minWidth: 220,
+              width: { xs: '100%', sm: 'auto' },
+              minWidth: { xs: '100%', sm: 220 },
               borderColor: 'success.main',
               color: 'success.main',
               '&:hover': {
@@ -193,7 +204,7 @@ export function DenunciaSucesso() {
           >
             Voltar ao Início
           </Button>
-        </Box>
+        </Stack>
       </Paper>
 
       <Snackbar


### PR DESCRIPTION
Este  pull request corrige um problema de quebra de layout na tela de "Denúncia Recebida com Sucesso" quando visualizada em dispositivos móveis.

O Problema
Os botões "Acompanhar Agora" e "Voltar ao Início" estavam configurados com uma largura mínima (minWidth: 220px) e dispostos em linha (flex-direction: row). Em telas de celular, a soma da largura dos botões ultrapassava a largura da tela, causando um "overflow" e quebrando o layout.
A solução foi aplicar as propriedades responsivas do Material-UI (MUI) diretamente no <'Box'> que agrupa os botões e nos próprios botões:

Os botões agora usam width: { xs: '100%', sm: 220 }.

Em telas pequenas, eles ocupam 100% da largura para facilitar o toque.

Em telas maiores, mantêm a largura fixa de 220px.

![Imagem do WhatsApp de 2025-10-21 à(s) 16 31 14_10cf7c12](https://github.com/user-attachments/assets/fef2f51a-dff2-4a6e-8472-255d38ce66a1)