### PR TITLE
removendo espaço em branco no v5

### DIFF
--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/autenticacao/Usuario.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/autenticacao/Usuario.java
@@ -31,7 +31,6 @@ import java.util.List;
 
 @Entity
 @Table(name = "usuarios")
-
 public class Usuario implements Serializable {
   private static final long serialVersionUID = 1L;
   @Id

--- a/apps/ifala-backend/src/main/resources/db/migration/V5__usuarios_e_roles.sql
+++ b/apps/ifala-backend/src/main/resources/db/migration/V5__usuarios_e_roles.sql
@@ -69,6 +69,6 @@ WHERE email IN (
   'thiagomoraisjacobina@gmail.com',
   'cacor.2020121tads0005@aluno.ifpi.edu.br',
   'cacor.2019121tads0028@aluno.ifpi.edu.br', 
-  'rene.moraes@ifpi.edu.br' 
+  'rene.moraes@ifpi.edu.br'
 )
 ON CONFLICT (usuarios_id, perfil) DO NOTHING;


### PR DESCRIPTION
# Removi o espaço em branco do V5

Para realizar os testes, removi os usuários e deixei somente o meu para não poluir o email dos demais. Na hora de colar novamente, acabei adicionando um espaço em branco sem perceber.

Para não prejudicar, estou enviando o V5 arrumado logo. Daqui a pouco envio a correção do sino para ficar responsivo no celular.

