### PR TITLE
feat: add custom config ssl and upload size

### DIFF
--- a/docker-compose-prd.yml
+++ b/docker-compose-prd.yml
@@ -17,6 +17,7 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_INITDB_ARGS: '--data-checksums'
       POSTGRES_HOST_AUTH_METHOD: scram-sha-256
+      TZ: America/Sao_Paulo
     command:
       - 'postgres'
       - '-c'
@@ -86,6 +87,8 @@ services:
     build:
       context: ./apps/ifala-frontend
       dockerfile: Dockerfile.prd
+      args:
+        - VITE_RECAPTCHA_KEY=${VITE_RECAPTCHA_KEY}
     container_name: ifala-frontend-prd
     restart: always
     networks:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -127,7 +127,7 @@ server {
     # Location /grafana - Grafana Dashboard
     # ========================================
     location /grafana/ {
-        proxy_pass http://grafana-prd:3000/;
+        proxy_pass http://grafana-prd:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
### Descrição
- Remoção de cyphers desatualizados
- Ajuste na configuração no tamanho do body de requisições que chegam ao nginx (default=1MB) para que ele não bloqueie denúncias com uploads.
- Ajuste na configuração no tamanho de cada arquivo multipart e da requisição no geral que chega ao Spring para 20MB.