### PR TITLE
feat: adiciona backdrop com loading ao enviar denúncia

### DIFF
--- a/apps/ifala-frontend/src/pages/Denuncia/Denuncia.tsx
+++ b/apps/ifala-frontend/src/pages/Denuncia/Denuncia.tsx
@@ -18,6 +18,7 @@ import {
   Alert,
   Button,
   CircularProgress,
+  Backdrop,
   type SelectChangeEvent,
 } from '@mui/material';
 //import ReCAPTCHA from 'react-google-recaptcha';
@@ -322,6 +323,7 @@ export function Denuncia() {
       navigate('/denuncia/sucesso', {
         state: { token: response.tokenAcompanhamento },
       });
+      // Não desativa o submitting aqui - mantém o overlay até a próxima página carregar
     } catch (error) {
       console.error('Erro ao criar denúncia:', error);
 
@@ -340,7 +342,7 @@ export function Denuncia() {
           'Erro ao enviar denúncia. Por favor, tente novamente mais tarde.',
         );
       }
-    } finally {
+      // Só desativa o submitting se houver erro
       setSubmitting(false);
     }
   };
@@ -834,6 +836,36 @@ export function Denuncia() {
           </Paper>
         )}
       </Container>
+
+      {/* Backdrop com loading durante o envio */}
+      <Backdrop
+        sx={{
+          color: '#fff',
+          zIndex: (theme) => theme.zIndex.drawer + 1,
+          backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        }}
+        open={submitting}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 2,
+          }}
+        >
+          <CircularProgress
+            size={60}
+            sx={{ color: 'var(--verde-esperanca)' }}
+          />
+          <Typography variant='h6' sx={{ color: '#fff', fontWeight: 'bold' }}>
+            Enviando sua denúncia...
+          </Typography>
+          <Typography variant='body2' sx={{ color: '#fff' }}>
+            Por favor, aguarde. Isso pode levar alguns segundos.
+          </Typography>
+        </Box>
+      </Backdrop>
     </Box>
   );
 }


### PR DESCRIPTION
## Descrição

Implementa feedback visual de loading durante o envio de denúncias, conforme solicitado na issue #196. Adiciona um overlay (Backdrop) com spinner que permanece ativo durante todo o processo de envio até a página de sucesso carregar completamente.

## Mudanças realizadas

-  Adicionado componente `Backdrop` do Material-UI sobre toda a página
-  Exibe spinner circular verde com mensagens informativas durante o envio
-  Overlay permanece ativo até o redirecionamento para `/denuncia/sucesso` completar
-  Em caso de erro, o overlay é removido permitindo nova tentativa
-  Impede interação do usuário com o formulário durante o envio

## Comportamento

**Sucesso:**
1. Usuário clica em "Enviar Denúncia"
2. Backdrop aparece com loading e mensagem "Enviando sua denúncia..."
3. Overlay permanece visível até a página de sucesso carregar
4. Sem "flash" entre páginas, transição suave

**Erro:**
1. Backdrop aparece normalmente
2. Em caso de erro na API, o overlay é removido
3. Usuário pode corrigir e tentar novamente

## Issue relacionada

Closes #196