### PR TITLE
FIX: remove perfil de usuário padrão do cadastro de usuários

### DIFF
--- a/apps/ifala-frontend/src/pages/GerenciamentoUsuarios/components/FormularioUsuario/FormularioUsuario.tsx
+++ b/apps/ifala-frontend/src/pages/GerenciamentoUsuarios/components/FormularioUsuario/FormularioUsuario.tsx
@@ -59,7 +59,7 @@ export function FormularioUsuario({
     email: '',
     senha: '',
     confirmarSenha: '',
-    roles: ['ANONIMO'],
+    roles: ['ADMIN'],
     mustChangePassword: true,
   });
 
@@ -184,7 +184,7 @@ export function FormularioUsuario({
       email: '',
       senha: '',
       confirmarSenha: '',
-      roles: ['ANONIMO'],
+      roles: ['ADMIN'],
       mustChangePassword: true,
     });
     setErrors({});
@@ -318,12 +318,12 @@ export function FormularioUsuario({
               </InputLabel>
               <Select
                 name='perfil'
-                value={formData.roles[0] === 'ADMIN' ? 'ADMIN' : 'USER'}
+                value='ADMIN'
                 label='Perfil de Acesso *'
                 onChange={(e) =>
                   setFormData((prev) => ({
                     ...prev,
-                    roles: [e.target.value as 'ADMIN' | 'USER'],
+                    roles: [e.target.value as 'ADMIN'],
                   }))
                 }
                 disabled={loading}
@@ -333,7 +333,6 @@ export function FormularioUsuario({
                   },
                 }}
               >
-                <MenuItem value='USER'>Usuário Padrão</MenuItem>
                 <MenuItem value='ADMIN'>Administrador</MenuItem>
               </Select>
             </FormControl>


### PR DESCRIPTION
- Remove opção 'Usuário Padrão' (USER) do select de perfil
- Deixa apenas o perfil de 'Administrador' (ADMIN)
- Atualiza valor padrão do campo roles para ['ADMIN']
- Atualiza função resetForm para usar 'ADMIN' como padrão

Issue #199