### PR TITLE
feat: Limpar o formulário para evitar reenvio acidental

### DIFF
--- a/apps/ifala-frontend/src/pages/Login/Login.tsx
+++ b/apps/ifala-frontend/src/pages/Login/Login.tsx
@@ -165,6 +165,9 @@ export function Login() {
           errorMessage.includes('Um e-mail de redefinição foi enviado')
         ) {
           setSuccessMessage(errorMessage);
+          // Limpa o formulário para evitar reenvio acidental
+          setFormData({ matricula: '', senha: '' });
+          setErrors({ matricula: '', senha: '' });
         } else if ('response' in err) {
           const axiosError = err as {
             response?: { data?: { message?: string } };
@@ -214,6 +217,10 @@ export function Login() {
       setSuccessMessage(
         `Email enviado com sucesso para ${formData.matricula}! Confira sua caixa de entrada e siga as instruções para redefinir sua senha.`,
       );
+
+      // Limpa o formulário para evitar reenvio acidental
+      setFormData({ matricula: '', senha: '' });
+      setErrors({ matricula: '', senha: '' });
 
       // Limpar erro se existir
       setError('');


### PR DESCRIPTION
# Implementado o reset do estado do formulário (formData e errors) após a detecção de senha temporária:

<img width="694" height="884" alt="image" src="https://github.com/user-attachments/assets/4bf619df-6f89-422b-8273-11603d185fc1" />



<img width="748" height="841" alt="image" src="https://github.com/user-attachments/assets/c9a3ad8b-c08c-486d-8fbb-1688fa6efcb2" />
