### PR TITLE
Fix: Remove duplicata de  @Component annotation no JwtAuthenticationFilter

### DIFF
--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/security/JwtAuthenticationFilter.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/security/JwtAuthenticationFilter.java
@@ -12,7 +12,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
@@ -25,8 +24,6 @@ import java.io.IOException;
  * 
  * @author Phaola
  */
-
-@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private static final Logger logger = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
 


### PR DESCRIPTION
## Problema

O backend estava falhando ao iniciar com o seguinte erro: 

```
Error creating bean with name 'jwtAuthenticationFilter': 
Unsatisfied dependency expressed through method 'jwtAuthenticationFilter' parameter 1:
Error creating bean with name 'customUserDetailsService': 
Unsatisfied dependency expressed through constructor parameter 0:
Error creating bean with name 'usuarioRepository': 
Cannot resolve reference to bean 'jpaSharedEM_entityManagerFactory'
```

### Causa Raiz

A classe `JwtAuthenticationFilter` possuía **duas definições conflitantes de bean**:

1. CORRETO -> `@Bean` no `SecurityConfig.java` (linha 49-51) - **Correto**
2. ERRADO -> `@Component` na própria classe (linha 29) - **Incorreto e causando conflito**

Isso criava uma **dependência circular** onde: 
- Spring tentava criar o filtro como `@Component`
- Simultaneamente tentava criá-lo como `@Bean`
- Ambos dependiam de `UserDetailsService` → `UsuarioRepository` → `EntityManagerFactory`
- O `EntityManagerFactory` não conseguia inicializar porque o Spring Security estava tentando inicializar antes do JPA

## Solução

Removi a anotação `@Component` e seu import da classe `JwtAuthenticationFilter`, mantendo apenas a definição como `@Bean` no `SecurityConfig.java`.

### Alterações realizadas: 

**Arquivo:** `apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/security/JwtAuthenticationFilter. java`

- Removido:  `import org.springframework.stereotype.Component;`
- Removido: `@Component` antes da declaração da classe

### Por que isso resolve?

1. **Definição única de bean**: Com apenas o `@Bean` no `SecurityConfig`, o Spring cria o filtro de forma controlada
2. **Ordem de inicialização correta**: O Spring consegue inicializar o JPA antes do Spring Security
3. **Sem dependência circular**: A cadeia de dependências fica linear: 
   ```
   EntityManagerFactory → UsuarioRepository → CustomUserDetailsService → JwtAuthenticationFilter → SecurityFilterChain
   ```

## Checklist

- [ ] Erro de inicialização corrigido
- [ ] Backend inicia com sucesso
- [ ] Endpoints `/api/v1/utils/*` respondem corretamente (200 OK)
- [ ] Autenticação JWT continua funcionando
- [ ] Sem warnings de beans duplicados

## Como Testar

1. **Iniciar o backend:**
   ```bash
   docker-compose up --build
   ```

2. **Verificar que inicia sem erros** (logs devem mostrar "Started IfalaApplication")

3. **Testar endpoints públicos:**
   ```bash
   curl http://localhost:5173/api/v1/utils/graus
   curl http://localhost:5173/api/v1/utils/categorias
   curl http://localhost:5173/api/v1/utils/anos
   curl http://localhost:5173/api/v1/utils/cursos
   curl http://localhost:5173/api/v1/utils/turmas
   ```
   Todos devem retornar 200 OK (não mais 500)

4. **Testar página de denúncia** no frontend - não deve mais mostrar erros no console

## Contexto Adicional

### Padrão correto para filtros do Spring Security: 

- **Filtros** devem ser definidos como `@Bean` em classes `@Configuration`
- **NÃO** devem usar `@Component`, `@Service`, etc.
- Isso dá controle explícito sobre a ordem de inicialização e evita conflitos

