### PR TITLE
feat: Ajuste implementados

### DIFF
--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/Denuncia.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/Denuncia.java
@@ -28,10 +28,8 @@ import java.util.Set;
 import java.util.UUID;
 
 /**
- * Classe que representa uma denúncia no sistema. Esta entidade armazena
- * informações sobre
- * denúncias, incluindo sua descrição, categoria, status e histórico de
- * acompanhamentos.
+ * Classe que representa uma denúncia no sistema. Esta entidade armazena informações sobre
+ * denúncias, incluindo sua descrição, categoria, status e histórico de acompanhamentos.
  *
  * @author Renê Morais
  * @author Jhonatas G Ribeiro
@@ -92,8 +90,7 @@ public class Denuncia implements Serializable {
   private Denunciante denunciante;
 
   /**
-   * Construtor padrão que inicializa uma nova denúncia. Define um token de
-   * acompanhamento único,
+   * Construtor padrão que inicializa uma nova denúncia. Define um token de acompanhamento único,
    * status inicial como RECEBIDO e a data/hora de criação.
    */
 

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/DenunciaService.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/DenunciaService.java
@@ -8,6 +8,7 @@ import br.edu.ifpi.ifala.denuncia.denunciaDTO.CriarDenunciaDto;
 import br.edu.ifpi.ifala.denuncia.denunciaDTO.DadosDeIdentificacaoDto;
 import br.edu.ifpi.ifala.denuncia.denunciaDTO.DenunciaAdminResponseDto;
 import br.edu.ifpi.ifala.denuncia.denunciaDTO.DenunciaResponseDto;
+import br.edu.ifpi.ifala.denuncia.denunciaDTO.DenuncianteResponseDto;
 import br.edu.ifpi.ifala.notificacao.NotificacaoExternaService;
 import br.edu.ifpi.ifala.prova.ProvaService;
 import br.edu.ifpi.ifala.security.recaptcha.RecaptchaService;
@@ -418,9 +419,18 @@ public class DenunciaService {
     boolean temMensagemNaoLida = acompanhamentoRepository
         .existsByDenunciaIdAndAutorAndVisualizadoFalse(denuncia.getId(), Perfis.ADMIN);
 
+    // Mapear dados do denunciante, se existir e se deseja se identificar
+    DenuncianteResponseDto denuncianteDto = null;
+    if (denuncia.isDesejaSeIdentificar() && denuncia.getDenunciante() != null) {
+      Denunciante denunciante = denuncia.getDenunciante();
+      denuncianteDto =
+          new DenuncianteResponseDto(denunciante.getNomeCompleto(), denunciante.getGrau(),
+              denunciante.getCurso(), denunciante.getAno(), denunciante.getTurma());
+    }
+
     return new DenunciaResponseDto(denuncia.getId(), denuncia.getTokenAcompanhamento(),
         denuncia.getStatus(), denuncia.getCategoria(), denuncia.getCriadoEm(),
-        denuncia.getAlteradoEm(), temMensagemNaoLida);
+        denuncia.getAlteradoEm(), temMensagemNaoLida, denuncianteDto);
   }
 
   private DenunciaAdminResponseDto mapToDenunciaAdminResponseDto(Denuncia denuncia) {
@@ -428,9 +438,18 @@ public class DenunciaService {
     boolean temMensagemNaoLida = acompanhamentoRepository
         .existsByDenunciaIdAndAutorAndVisualizadoFalse(denuncia.getId(), Perfis.ANONIMO);
 
+    // Mapear dados do denunciante, se existir e se deseja se identificar
+    DenuncianteResponseDto denuncianteDto = null;
+    if (denuncia.isDesejaSeIdentificar() && denuncia.getDenunciante() != null) {
+      Denunciante denunciante = denuncia.getDenunciante();
+      denuncianteDto =
+          new DenuncianteResponseDto(denunciante.getNomeCompleto(), denunciante.getGrau(),
+              denunciante.getCurso(), denunciante.getAno(), denunciante.getTurma());
+    }
+
     return new DenunciaAdminResponseDto(denuncia.getId(), denuncia.getTokenAcompanhamento(),
         denuncia.getStatus(), denuncia.getCategoria(), denuncia.getCriadoEm(),
-        denuncia.getAlteradoEm(), temMensagemNaoLida);
+        denuncia.getAlteradoEm(), temMensagemNaoLida, denuncianteDto);
   }
 
   private AcompanhamentoDto mapToAcompanhamentoResponseDto(Acompanhamento acompanhamento) {

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/denunciaDTO/DenunciaAdminResponseDto.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/denunciaDTO/DenunciaAdminResponseDto.java
@@ -16,5 +16,5 @@ import java.util.UUID;
  */
 public record DenunciaAdminResponseDto(Long id, UUID tokenAcompanhamento, Status status,
     Categorias categoria, LocalDateTime criadoEm, LocalDateTime alteradoEm,
-    Boolean temMensagemNaoLida) {
+    Boolean temMensagemNaoLida, DenuncianteResponseDto denunciante) {
 }

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/denunciaDTO/DenunciaResponseDto.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/denunciaDTO/DenunciaResponseDto.java
@@ -12,7 +12,7 @@ import java.util.UUID;
  */
 public record DenunciaResponseDto(Long id, UUID tokenAcompanhamento, Status status,
     Categorias categoria, LocalDateTime criadoEm, LocalDateTime alteradoEm,
-    Boolean temMensagemNaoLida) {
+    Boolean temMensagemNaoLida, DenuncianteResponseDto denunciante) {
   @Override
   public String toString() {
     return "DenunciaResponseDto[" + "id=" + id

--- a/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/denunciaDTO/DenuncianteResponseDto.java
+++ b/apps/ifala-backend/src/main/java/br/edu/ifpi/ifala/denuncia/denunciaDTO/DenuncianteResponseDto.java
@@ -1,0 +1,15 @@
+package br.edu.ifpi.ifala.denuncia.denunciaDTO;
+
+import br.edu.ifpi.ifala.shared.enums.Ano;
+import br.edu.ifpi.ifala.shared.enums.Curso;
+import br.edu.ifpi.ifala.shared.enums.Grau;
+import br.edu.ifpi.ifala.shared.enums.Turma;
+
+/**
+ * Data Transfer Object (DTO) para representar os dados do denunciante em uma resposta.
+ * 
+ * @author Phaola
+ */
+public record DenuncianteResponseDto(String nomeCompleto, Grau grau, Curso curso, Ano ano,
+    Turma turma) {
+}

--- a/apps/ifala-frontend/src/types/acompanhamento.ts
+++ b/apps/ifala-frontend/src/types/acompanhamento.ts
@@ -1,9 +1,18 @@
+export interface DenuncianteInfo {
+  nomeCompleto: string;
+  grau: string;
+  curso: string;
+  ano: string | null;
+  turma: string;
+}
+
 export interface AcompanhamentoDetalhes {
   id: number;
   tokenAcompanhamento: string;
   status: string;
   categoria: string;
   criadoEm: string;
+  denunciante?: DenuncianteInfo | null;
 }
 
 export interface MensagemAcompanhamento {


### PR DESCRIPTION
# Agora é mostrado o nome do denunciante não anônimo no balão de mensagem:

<img width="1574" height="586" alt="image" src="https://github.com/user-attachments/assets/00307725-0a72-44ed-bb68-c46b5780c819" />

# Ao clicar no nome do aluno será exibido um modal com mais informações do aluno, não achei necessário incluir email:

<img width="1400" height="670" alt="image" src="https://github.com/user-attachments/assets/3fe05413-4a76-40d8-b499-3e69d2e2886b" />
